### PR TITLE
fix: deduplicate `vim` entry in `en.utf-8.add`

### DIFF
--- a/config/nvim/spell/en.utf-8.add
+++ b/config/nvim/spell/en.utf-8.add
@@ -5,7 +5,6 @@ plugins
 todo
 lua
 Neovim
-vim
 quickfix
 todos
 popup


### PR DESCRIPTION
Signed-off-by: Vladislav Doster <mvdoster@gmail.com>