### PR TITLE
avoid statuscolumn layout shift

### DIFF
--- a/config/nvim/lua/util/status.lua
+++ b/config/nvim/lua/util/status.lua
@@ -25,7 +25,7 @@ function M.column()
     nu = vim.v.relnum == 0 and vim.v.lnum or vim.v.relnum
   end
   local components = {
-    sign and ("%#" .. sign.texthl .. "#" .. sign.text .. "%*") or " ",
+    sign and ("%#" .. sign.texthl .. "#" .. sign.text .. "%*") or "  ",
     [[%=]],
     nu .. " ",
     git_sign and ("%#" .. git_sign.texthl .. "#" .. git_sign.text .. "%*") or "  ",


### PR DESCRIPTION
Hey @folke! 

Thanks again for your help on [this reddit thread](https://www.reddit.com/r/neovim/comments/10k92y4/comment/j5ptskt/?utm_source=share&utm_medium=web2x&context=3). I was able to get my [statuscolumn](https://github.com/jrnxf/dot/blob/main/config/nvim/lua/util/status.lua) just the way I wanted. 

One thing I noticed while messing around with your snippet though, is that on some diagnostic errors (for sure if on the first line) you get a layout shift:


https://user-images.githubusercontent.com/21346716/214492610-a2639b3f-26bd-4215-b185-7febe7bf5425.mov

I was able to solve this by adding an extra space for when there isn't a diagnostic sign.

Cheers!
